### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Check your source, before you push. Results log are place to build/logs
     phing build-local
 
 ### Testing CakePHP only ###
-Only testing, exclude coverage caluculate.
+Only testing, exclude coverage calculate.
 
     app/Console/cake test app AllTests
     app/Console/cake test app Model/Foo


### PR DESCRIPTION
@uluru, I've corrected a typographical error in the documentation of the [phing-cakephp](https://github.com/uluru/phing-cakephp) project. Specifically, I've changed caluculate to calculate. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
